### PR TITLE
Fix argument order for diffUTCTime call in totalTime

### DIFF
--- a/Geo/Computations/Trail.hs
+++ b/Geo/Computations/Trail.hs
@@ -382,7 +382,7 @@ totalDistance as = sum $ zipWith distance as (drop 1 as)
 
 totalTime :: Trail Point -> NominalDiffTime
 totalTime [] = 0
-totalTime xs@(x:_) = fromMaybe 0 $ liftM2 diffUTCTime (pntTime x) (pntTime $ last xs)
+totalTime xs@(x:_) = fromMaybe 0 $ liftM2 diffUTCTime (pntTime $ last xs) (pntTime x)
 
 -- | Uses Grahams scan to compute the convex hull of the given points.
 -- This operation requires sorting of the points, so don't try it unless


### PR DESCRIPTION
Note that `diffUTCTime` is implemented as subtraction of second argument from first - if I'm correct to assume that `totalTime x` expects `linearTime x == x` then it looks like the argument application to `diffUTCTime` in `totalTime` is currently backwards.